### PR TITLE
fix: Inconsistent trailing slash in VGS Collect submit URLs

### DIFF
--- a/src/collector/VGSCollect.ts
+++ b/src/collector/VGSCollect.ts
@@ -598,7 +598,11 @@ class VGSCollect {
 
     if (parsedUrl) {
       // Return a canonical URL so reserved chars are encoded, not stripped.
-      return parsedUrl.toString();
+      let canonical = parsedUrl.toString();
+      if (!resultUrl.endsWith('/') && canonical.endsWith('/')) {
+        canonical = canonical.slice(0, -1);
+      }
+      return canonical;
     } else {
       throw new VGSError(VGSErrorCode.InvalidConfigurationURL, 'Invalid URL', {
         URL: resultUrl,


### PR DESCRIPTION
## Summary
collector.submit() was intermittently hitting endpoints with an unwanted trailing slash (e.g. /post/ instead of /post), causing inconsistent behavior against our proxy routes. This patches the SDK's internal buildUrl method to strip a trailing slash that wasn't present in the original input path.
## Root cause
buildUrl constructs the request URL, then returns new URL(resultUrl).toString() for canonical serialization (so reserved characters are properly encoded rather than stripped). The serialization step can non-deterministically append a trailing slash depending on the underlying URL implementation, even when the input path never had one — so /post can come out as /post/.
## Fix
Ensure canonical URL does not end with a trailing slash if the original URL does not.
This preserves the SDK's original intent (canonical, properly-encoded URLs) while guarding against the one case where serialization silently changes the requested path.